### PR TITLE
bump react-native version, it fixes npm install error "peer tcomb-form-native@0…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react-native": "^0.4.0",
+    "react-native": "^0.5.0",
     "tcomb-form-native": "^0.1.7"
   }
 }


### PR DESCRIPTION
….1.9 wants react-native@^0.5.0"
